### PR TITLE
Add HTML email templates for OTP notifications

### DIFF
--- a/server/config/emailTemplates.js
+++ b/server/config/emailTemplates.js
@@ -1,0 +1,219 @@
+export const EMAIL_VERIFY_TEMPLATE = `
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <title>Email Verify</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" type="text/css">
+  <style type="text/css">
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: 'Open Sans', sans-serif;
+      background: #E5E5E5;
+    }
+
+    table, td {
+      border-collapse: collapse;
+    }
+
+    .container {
+      width: 100%;
+      max-width: 500px;
+      margin: 70px 0px;
+      background-color: #ffffff;
+    }
+
+    .main-content {
+      padding: 48px 30px 40px;
+      color: #000000;
+    }
+
+    .button {
+      width: 100%;
+      background: #22D172;
+      text-decoration: none;
+      display: inline-block;
+      padding: 10px 0;
+      color: #fff;
+      font-size: 14px;
+      text-align: center;
+      font-weight: bold;
+      border-radius: 7px;
+    }
+
+    @media only screen and (max-width: 480px) {
+      .container {
+        width: 80% !important;
+      }
+
+      .button {
+        width: 50% !important;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <table width="100%" cellspacing="0" cellpadding="0" border="0" align="center" bgcolor="#F6FAFB">
+    <tbody>
+      <tr>
+        <td valign="top" align="center">
+          <table class="container" width="600" cellspacing="0" cellpadding="0" border="0">
+            <tbody>
+              <tr>
+                <td class="main-content">
+                  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+                    <tbody>
+                      <tr>
+                        <td style="padding: 0 0 24px; font-size: 18px; line-height: 150%; font-weight: bold;">
+                          Verify your email
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 0 0 10px; font-size: 14px; line-height: 150%;">
+                          You are just one step away to verify your account for this email: <span style="color: #4C83EE;">{{email}}</span>.
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 0 0 16px; font-size: 14px; line-height: 150%; font-weight: 700;">
+                          Use below OTP to verify your account.
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 0 0 24px;">
+                          <p class="button" >{{otp}}</p>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 0 0 10px; font-size: 14px; line-height: 150%;">
+                          This OTP is valid for 24 hours.
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</body>
+</html>
+
+`;
+
+export const PASSWORD_RESET_TEMPLATE = `
+
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <title>Password Reset</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap" rel="stylesheet" type="text/css">
+  <style type="text/css">
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: 'Open Sans', sans-serif;
+      background: #E5E5E5;
+    }
+
+    table, td {
+      border-collapse: collapse;
+    }
+
+    .container {
+      width: 100%;
+      max-width: 500px;
+      margin: 70px 0px;
+      background-color: #ffffff;
+    }
+
+    .main-content {
+      padding: 48px 30px 40px;
+      color: #000000;
+    }
+
+    .button {
+      width: 100%;
+      background: #22D172;
+      text-decoration: none;
+      display: inline-block;
+      padding: 10px 0;
+      color: #fff;
+      font-size: 14px;
+      text-align: center;
+      font-weight: bold;
+      border-radius: 7px;
+    }
+
+    @media only screen and (max-width: 480px) {
+      .container {
+        width: 80% !important;
+      }
+
+      .button {
+        width: 50% !important;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <table width="100%" cellspacing="0" cellpadding="0" border="0" align="center" bgcolor="#F6FAFB">
+    <tbody>
+      <tr>
+        <td valign="top" align="center">
+          <table class="container" width="600" cellspacing="0" cellpadding="0" border="0">
+            <tbody>
+              <tr>
+                <td class="main-content">
+                  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+                    <tbody>
+                      <tr>
+                        <td style="padding: 0 0 24px; font-size: 18px; line-height: 150%; font-weight: bold;">
+                          Forgot your password?
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 0 0 10px; font-size: 14px; line-height: 150%;">
+                          We received a password reset request for your account: <span style="color: #4C83EE;">{{email}}</span>.
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 0 0 16px; font-size: 14px; line-height: 150%; font-weight: 700;">
+                          Use the OTP below to reset the password.
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 0 0 24px;">
+                          <p class="button" >{{otp}}</p>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 0 0 10px; font-size: 14px; line-height: 150%;">
+                          The password reset otp is only valid for the next 15 minutes.
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</body>
+</html>
+`;

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -2,6 +2,10 @@ import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import userModel from "../models/userModel.js";
 import transporter from "../config/nodeMailer.js";
+import {
+  EMAIL_VERIFY_TEMPLATE,
+  PASSWORD_RESET_TEMPLATE,
+} from "../config/emailTemplates.js";
 
 // Register function
 export const register = async (req, res) => {
@@ -123,7 +127,11 @@ export const sendVerifyOtp = async (req, res) => {
       from: process.env.SENDER_EMAIL,
       to: user.email,
       subject: "Account verification OTP",
-      text: `Your OTP is ${otp}. Verify your account using this OTP.`,
+      // text: `Your OTP is ${otp}. Verify your account using this OTP.`,
+      html: EMAIL_VERIFY_TEMPLATE.replace("{{otp}}", otp).replace(
+        "{{email}}",
+        user.email
+      ),
     };
     await transporter.sendMail(mailOptions);
 
@@ -203,8 +211,13 @@ export const sendResetOtp = async (req, res) => {
       from: process.env.SENDER_EMAIL,
       to: user.email,
       subject: "Password reset OTP",
-      text: `Your OTP for resetting your password is ${otp}. Use this OTP tp proceed with resetting your password.`,
+      // text: `Your OTP for resetting your password is ${otp}. Use this OTP tp proceed with resetting your password.`,
+      html: PASSWORD_RESET_TEMPLATE.replace("{{otp}}", otp).replace(
+        "{{email}}",
+        user.email
+      ),
     };
+
     await transporter.sendMail(mailOptions);
 
     return res.json({ success: true, message: "OTP sent to your email" });


### PR DESCRIPTION
Introduced EMAIL_VERIFY_TEMPLATE and PASSWORD_RESET_TEMPLATE for sending styled HTML emails during account verification and password reset. Updated authController to use these templates instead of plain text emails, improving user experience and email presentation.